### PR TITLE
feat: add additional_accepted_prefixes support, e.g. for router NAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ This plugin gets the instance information from the OpenStack API and attestates 
 3. Get the role configuration based on the role name. If the role configuration does not exist, the authenticate fails.
 4. Validate the authentication period specified in the role with the creation time of the instance. If the deadline was exceeded, the authentication fails.
 5. Validate the limit of authentication attempt count specified in the role. If authentication exceeds the maximum number of attempts, the authentication fails.
-6. Validate the instance IP address with the remote IP address of `vault login`. If address mismatched, the authentication fails. If configured also the IP addresses from the request headers are used for validation.
+6. Validate the instance IP address with the remote IP address of `vault login`. If address mismatched, the authentication fails. If configured also the IP addresses from the request headers are used for validation. The role config can contain additional prefixes to accept, e.g. when the instance is using the router NAT.
 7. Validate the status of the instance. If the instance is not active, the authentication fails.
 8. Validate the role name contained in the metadata of the instance with the key specified in the role configuration. If the key of metadata does not exist or role name is mismatched, the authentication fails.
 9. Validate the tenant ID of the instance with the role configuration. If the tenand ID is mismatched, the authentication fails. This validation is performed only if the tenant ID is specified in the role configuration.

--- a/plugin/path_login.go
+++ b/plugin/path_login.go
@@ -194,7 +194,7 @@ func (b *OpenStackAuthBackend) authRenewHandler(ctx context.Context, req *logica
 			attestAddresses = append(attestAddresses, val...)
 		}
 	}
-	err = attestor.AttestAddr(instance, attestAddresses)
+	err = attestor.AttestAddr(instance, attestAddresses, role.AdditionalAcceptedPrefixes)
 	if err != nil {
 		return logical.ErrorResponse(fmt.Sprintf("failed to renew: %v", err)), nil
 	}

--- a/plugin/role.go
+++ b/plugin/role.go
@@ -4,25 +4,27 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
 type Role struct {
-	Name        string        `json:"name" structs:"name" mapstructure:"name"`
-	Policies    []string      `json:"policies" structs:"policies" mapstructure:"policies"`
-	TTL         time.Duration `json:"ttl" structs:"ttl" mapstructure:"ttl"`
-	MaxTTL      time.Duration `json:"max_ttl" structs:"max_ttl" mapstructure:"max_ttl"`
-	Period      time.Duration `json:"period" structs:"period" mapstructure:"period"`
-	MetadataKey string        `json:"metadata_key" structs:"metadata_key" mapstructure:"metadata_key"`
-	TenantID    string        `json:"tenant_id" structs:"tenant_id" mapstructure:"tenant_id"`
-	TenantName  string        `json:"tenant_name" structs:"tenant_name" mapstructure:"tenant_name"`
-	ProjectID   string        `json:"project_id" structs:"project_id" mapstructure:"project_id"`
-	ProjectName string        `json:"project_name" structs:"project_name" mapstructure:"project_name"`
-	UserID      string        `json:"user_id" structs:"user_id" mapstructure:"user_id"`
-	AuthPeriod  time.Duration `json:"auth_period" structs:"auth_period" mapstructure:"auth_period"`
-	AuthLimit   int           `json:"auth_limit" structs:"auth_limit" mapstructure:"auth_limit"`
+	Name                       string        `json:"name" structs:"name" mapstructure:"name"`
+	Policies                   []string      `json:"policies" structs:"policies" mapstructure:"policies"`
+	TTL                        time.Duration `json:"ttl" structs:"ttl" mapstructure:"ttl"`
+	MaxTTL                     time.Duration `json:"max_ttl" structs:"max_ttl" mapstructure:"max_ttl"`
+	Period                     time.Duration `json:"period" structs:"period" mapstructure:"period"`
+	MetadataKey                string        `json:"metadata_key" structs:"metadata_key" mapstructure:"metadata_key"`
+	TenantID                   string        `json:"tenant_id" structs:"tenant_id" mapstructure:"tenant_id"`
+	TenantName                 string        `json:"tenant_name" structs:"tenant_name" mapstructure:"tenant_name"`
+	ProjectID                  string        `json:"project_id" structs:"project_id" mapstructure:"project_id"`
+	ProjectName                string        `json:"project_name" structs:"project_name" mapstructure:"project_name"`
+	UserID                     string        `json:"user_id" structs:"user_id" mapstructure:"user_id"`
+	AuthPeriod                 time.Duration `json:"auth_period" structs:"auth_period" mapstructure:"auth_period"`
+	AuthLimit                  int           `json:"auth_limit" structs:"auth_limit" mapstructure:"auth_limit"`
+	AdditionalAcceptedPrefixes []string      `json:"additional_accepted_prefixes" structs:"additional_accepted_prefixes" mapstructure:"additional_accepted_prefixes"`
 }
 
 func (r *Role) Validate(sys logical.SystemView) (warnings []string, err error) {
@@ -64,6 +66,12 @@ func (r *Role) Validate(sys logical.SystemView) (warnings []string, err error) {
 
 	if r.Period > sys.MaxLeaseTTL() {
 		return warnings, fmt.Errorf("'period' of '%s' is greater than the backend's maximum lease TTL of '%s'", r.Period, sys.MaxLeaseTTL())
+	}
+
+	for _, prefix := range r.AdditionalAcceptedPrefixes {
+		if _, _, err := net.ParseCIDR(prefix); err != nil {
+			return warnings, fmt.Errorf("'%s' is not a valid CIDR", prefix)
+		}
 	}
 
 	return warnings, nil


### PR DESCRIPTION
This adds support for additional accepted prefixes. When your instance is using the router NAT for logging in, it is necessary to accept the router IP additionally.